### PR TITLE
remove invalid pnpm version from github workflow

### DIFF
--- a/.github/workflows/deploy-report.yml
+++ b/.github/workflows/deploy-report.yml
@@ -19,11 +19,9 @@ jobs:
     name: Publish to Cloudflare Pages
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Removes invalid version since we now have packageManager field in package.json

(Deployment is broken)